### PR TITLE
error fix on the forum posts page

### DIFF
--- a/templates/simple_forums/thread_detail.html
+++ b/templates/simple_forums/thread_detail.html
@@ -28,7 +28,7 @@
                             </span>
                         </div>
                         <div class="panel-body" style="font-size: 1.2em;">
-                            {% render_markup message.body %}
+                            {{  message.body }}
                         </div>
                     </div>
                     <hr />


### PR DESCRIPTION
Removed `render_markup` as we are not using the markdown feature